### PR TITLE
Add create_exchange method

### DIFF
--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -110,7 +110,7 @@ module RabbitMQ
         decode_resource_collection(@connection.get(path))
       end
 
-      def create_exchange(vhost, name, attributes)
+      def create_exchange(vhost, name, attributes={})
         final_attrs = {
           "type" => "direct", 
           "auto_delete" => false, 
@@ -120,7 +120,7 @@ module RabbitMQ
 
         response = @connection.put("/api/exchanges/#{uri_encode(vhost)}/#{uri_encode(name)}") do |req|
           req.headers['Content-Type'] = 'application/json'
-          req.body = MultiJSON.dump(final_attrs)
+          req.body = MultiJson.dump(final_attrs)
         end
         decode_resource(response)
       end


### PR DESCRIPTION
This PR adds a method for creating an exchange by PUTing the `/api/exchanges/:vhost/:name` endpoint per [this document](http://hg.rabbitmq.com/rabbitmq-management/raw-file/3646dee55e02/priv/www-api/help.html).

It assumes the properties given by the example JSON for the attributes.

I'm hoping I didn't just miss the method (almost added a `create_binding` until I realized it existed), but let me know if I did. I managed to test this in a VM successfully.
