### PR TITLE
Relax dependency versioning in gemspec.

### DIFF
--- a/rabbitmq_http_api_client.gemspec
+++ b/rabbitmq_http_api_client.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency    "hashie",             "~> 3.2"
-  gem.add_dependency    "multi_json",         "~> 1.9"
-  gem.add_dependency    "faraday",            "~> 0.9.0"
-  gem.add_dependency    "faraday_middleware", "~> 0.9.0"
-  gem.add_dependency    "effin_utf8",         "~> 1.0.0"
+  gem.add_dependency    "hashie",             "~> 2"
+  gem.add_dependency    "multi_json",         "~> 1"
+  gem.add_dependency    "faraday",            "~> 0"
+  gem.add_dependency    "faraday_middleware", "~> 0"
+  gem.add_dependency    "effin_utf8",         "~> 1"
 end


### PR DESCRIPTION
Hi,

I have relaxed the gem dependency versioning and everything is working as expected.  The current versioning is much too strict and causing issues/additional work for people installing this gem, ie. forced gem upgrades that introduce risk.  It is good to have the most relaxed gem dependencies you can possibly have in order to make users lives easier (I learned this the hard way).

By the way, if you use ~> 1 it means any version of gem that does not have a major version change may be installed, ie. 1.2.4 -> 1.7.8.  However, when you use ~> 1.3, it means any version of the gem without a minor version change (so only patch increments, ie. 1.3.0 -> 1.3.4) may be used.  99% of the time the major version is sufficient and allows more people to use without updating lots of gems and incurring lots of regression bug risk in their applications.

Thanks for the hard work you put into this gem!
