### PR TITLE
Add changes to support URIs with path to changelog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,6 @@
 ## Changes Between 1.4.0 and 1.5.0
 
-No changes yet.
-
+Support for URIs containing a path.
 
 ## Changes Between 1.3.0 and 1.4.0
 


### PR DESCRIPTION
Could we release a version with this update? There's no workaround I can take other than forking and have a custom version in private gem repository (I'm building another gem that uses this one).