### PR TITLE
delete_exchange support for if-unused option

### DIFF
--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -129,8 +129,11 @@ module RabbitMQ
         decode_resource(response)
       end
 
-      def delete_exchange(vhost, name)
-        decode_resource(@connection.delete("exchanges/#{uri_encode(vhost)}/#{uri_encode(name)}"))
+      def delete_exchange(vhost, name, if_unused = false)
+        response = @connection.delete("exchanges/#{uri_encode(vhost)}/#{uri_encode(name)}") do |req|
+          req.params["if-unused"] = true if if_unused
+        end
+        decode_resource(response)
       end
 
       def exchange_info(vhost, name)

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -317,6 +317,15 @@ describe RabbitMQ::HTTP::Client do
       x = @channel.fanout(exchange_name, :durable => false)
       subject.delete_exchange("/", exchange_name)
     end
+
+    it "doesn't delete used exchange" do
+      q = @channel.queue("")
+      e = @channel.fanout(exchange_name, :durable => false)
+      q.bind(e)
+      expect do
+        subject.delete_exchange("/", exchange_name, true)
+      end.to raise_error(Faraday::ClientError)
+    end
   end
 
 


### PR DESCRIPTION
From HTTP API docs

```
When DELETEing an exchange you can add the query string parameter if-unused=true. 
This prevents the delete from succeeding if the exchange is bound to a queue or as 
a source to another exchange.
```