### PR TITLE
DO NOT MERGE Change message get mode for version 3.7.X

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ bs = client.list_queue_bindings("/", "collector1.megacorp.local")
 client.purge_queue("/", "collector1.megacorp.local")
 
 # Fetch messages from a queue
-ms = client.get_messages("/", "collector1.megacorp.local", :count => 10, :requeue => false, :encoding => "auto")
+ms = client.get_messages("/", "collector1.megacorp.local", :count => 10, :ackmode => "ack_requeue_false", :encoding => "auto")
 m  = ms.first
 
 puts m.properties.content_type

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -551,7 +551,7 @@ describe RabbitMQ::HTTP::Client do
       sleep 0.7
 
       expect(q.message_count).to eq(10)
-      xs = subject.get_messages("/", q.name, :count => 10, :requeue => false, :encoding => "auto")
+      xs = subject.get_messages("/", q.name, :count => 10, :ackmode => "ack_requeue_false", :encoding => "auto")
       m  = xs.first
 
       expect(m.properties.content_type).to eq("application/xyz")


### PR DESCRIPTION
The RabbitMQ version 3.7.x changed the [get message using the HTTP API](https://github.com/rabbitmq/rabbitmq-management/issues/68).

This PR should be merged when the 3.7.x  will be official.

Unit tests passed:

```
Finished in 3 minutes 0.8 seconds (files took 0.60178 seconds to load)
1074 examples, 0 failures, 4 pending
```
