### PR TITLE
Manage bindings between exchanges

### DIFF
--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -222,6 +222,27 @@ module RabbitMQ
         resp.success?
       end
 
+      def list_bindings_between_exchanges(vhost, destination_exchange, source_exchange)
+        decode_resource_collection(@connection.get("bindings/#{uri_encode(vhost)}/e/#{uri_encode(source_exchange)}/e/#{uri_encode(destination_exchange)}"))
+      end
+
+      def exchange_binding_info(vhost, destination_exchange, source_exchange, properties_key)
+        decode_resource(@connection.get("bindings/#{uri_encode(vhost)}/e/#{uri_encode(source_exchange)}/e/#{uri_encode(destination_exchange)}/#{uri_encode(properties_key)}"))
+      end
+
+
+      def bind_exchange(vhost, destination_exchange, source_exchange, routing_key, arguments = [])
+        resp = @connection.post("bindings/#{uri_encode(vhost)}/e/#{uri_encode(source_exchange)}/e/#{uri_encode(destination_exchange)}") do |req|
+          req.headers['Content-Type'] = 'application/json'
+          req.body = MultiJson.dump({:routing_key => routing_key, :arguments => arguments})
+        end
+        resp.headers['location']
+      end
+
+      def delete_exchange_binding(vhost, destination_exchange, source_exchange, properties_key)
+        resp = @connection.delete("bindings/#{uri_encode(vhost)}/e/#{uri_encode(source_exchange)}/e/#{uri_encode(destination_exchange)}/#{uri_encode(properties_key)}")
+        resp.success?
+      end
 
 
       def list_vhosts

--- a/lib/rabbitmq/http/client/version.rb
+++ b/lib/rabbitmq/http/client/version.rb
@@ -1,7 +1,7 @@
 module RabbitMQ
   module HTTP
     class Client
-      VERSION = "1.7.0.pre1"
+      VERSION = "1.7.1.pre1"
     end
   end
 end


### PR DESCRIPTION
Hi there,

I added methods for creating, deleting and getting info about bindings between exchanges.

I've been using RabbitMQ and your gem for quite some time now and never needed this feature but since I needed to add this to my application I thought it would be nice to add it to your gem.

I've also added rspec tests that run successfully on my setup and bumped gem version in order for you to publish it if you decide to merge my code.

Best regards,
Jose