### PR TITLE
Handle string response bodies

### DIFF
--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -422,7 +422,11 @@ module RabbitMQ
       end
 
       def decode_resource(response)
-        Hashie::Mash.new(response.body)
+        if response.body.instance_of? String then
+          Hashie::Mash.new Hash.new
+        else
+          Hashie::Mash.new(response.body)
+        end
       end
 
       def decode_resource_collection(response)


### PR DESCRIPTION
Not suggesting merging this code as it is as I really don't know how to write ruby but it should describe the problem that needs solving. In a recent RabbitMQ cowboy update it stopped including `Content-Type` headers in PUT responses. This seems to cause the code to return a string as the body of the response rather than something that can be "mashed" resulting in an error such as the one below:

```NoMethodError:
       undefined method `each_pair' for "":String
       Did you mean?  each_char
     # /usr/local/bundle/gems/hashie-3.6.0/lib/hashie/mash.rb:210:in `deep_update'
     # /usr/local/bundle/gems/hashie-3.6.0/lib/hashie/mash.rb:124:in `initialize'
     # /usr/local/bundle/gems/rabbitmq_http_api_client-1.9.1/lib/rabbitmq/http/client.rb:425:in `new'
     # /usr/local/bundle/gems/rabbitmq_http_api_client-1.9.1/lib/rabbitmq/http/client.rb:425:in `decode_resource'
     # /usr/local/bundle/gems/rabbitmq_http_api_client-1.9.1/lib/rabbitmq/http/client.rb:93:in `close_connection'
     # ./spec/higher_level_api/integration/connection_stop_spec.rb:21:in `close_connection'
     # ./spec/higher_level_api/integration/connection_stop_spec.rb:74:in `block (3 levels) in <top (required)>'```

There may be much better ways to handle this but this PR makes the test suite pass again against the latest RabbitMQ master branch.