### PR TITLE
Removing effin dependency

### DIFF
--- a/rabbitmq_http_api_client.gemspec
+++ b/rabbitmq_http_api_client.gemspec
@@ -22,5 +22,4 @@ Gem::Specification.new do |gem|
   gem.add_dependency    "multi_json",         "~> 1.12"
   gem.add_dependency    "faraday",            "~> 0.13.0"
   gem.add_dependency    "faraday_middleware", "~> 0.12.0"
-  gem.add_dependency    "effin_utf8",         "~> 1.0.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ require 'bundler'
 Bundler.setup(:default, :test)
 
 
-require "effin_utf8"
 require "rspec"
 require "json"
 require "rabbitmq/http/client"


### PR DESCRIPTION
Since recent rabbitmq_http_api_client releases drop support for ruby 1.x versions, there is no need to use this gem anymore. utf8 is the default encoding in ruby 2.x versions.