### PR TITLE
Expand constraint on Faraday gem to allow for version 0.17.3

### DIFF
--- a/rabbitmq_http_api_client.gemspec
+++ b/rabbitmq_http_api_client.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency    "hashie",             "~> 3.6"
   gem.add_dependency    "multi_json",         "~> 1.13.1"
-  gem.add_dependency    "faraday",            "~> 0.15.4"
-  gem.add_dependency    "faraday_middleware", "~> 0.13.0"
+  gem.add_dependency    "faraday",            [">= 0.15", "< 1"]
+  gem.add_dependency    "faraday_middleware", [">= 0.13.0", "< 1"]
 end


### PR DESCRIPTION
Faraday has recently released 1.0, and faraday_middleware is progressing that direction too. I'd like to upgrade these dependencies, and there does not seem to be any obstacle for this gem to allow its consumers to do so.

Regarding the decision on constraints, I chose `1` as the upper bound. Faraday_middleware's constraints do not yet permit version 1 of faraday. Version 0.17.3 is the highest version currently reachable by this constraint. That version introduces optional deprecation warnings useful to developers wishing to prepare the way to upgrade to 1.0, so it seemed a good point. 