### PR TITLE
Bumping all gems to newest versions

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -288,7 +288,7 @@ it possible to access the URI a client instance uses.
 ### Meaningful Exceptions for 4xx and 5xx Responses
 
 `4xx` and `5xx` responses now will result in meaningful exceptions
-being raised. For example, `404` responses will raise `Faraday::Error::ResourceNotFound`.
+being raised. For example, `404` responses will raise `Faraday::ResourceNotFound`.
 
 
 ## Changes Between 0.2.0 and 0.3.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem "rspec", "~> 3.8.0"
+  gem 'rspec', '~> 3.9'
   gem "json", :platform => :ruby_18
-  gem "bunny", "~> 2.14.2"
+  gem "bunny", "~> 2.15.0"
 
   gem "rantly"
 end

--- a/rabbitmq_http_api_client.gemspec
+++ b/rabbitmq_http_api_client.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency    "hashie",             "~> 3.6"
-  gem.add_dependency    "multi_json",         "~> 1.13.1"
-  gem.add_dependency    "faraday",            [">= 0.15", "< 1"]
-  gem.add_dependency    "faraday_middleware", [">= 0.13.0", "< 1"]
+  gem.add_dependency    'hashie', '~> 4.1'
+  gem.add_dependency    'multi_json', '~> 1.14', '>= 1.14.1'
+  gem.add_dependency    'faraday', '~> 1.0', '>= 1.0.1'
+  gem.add_dependency    'faraday_middleware', '~> 1.0'
 end

--- a/spec/integration/client_spec.rb
+++ b/spec/integration/client_spec.rb
@@ -474,7 +474,7 @@ describe RabbitMQ::HTTP::Client do
       it "raises NotFound" do
         expect do
           subject.queue_info("/", Time.now.to_i.to_s)
-        end.to raise_error(Faraday::Error::ResourceNotFound)
+        end.to raise_error(Faraday::ResourceNotFound)
       end
     end
   end
@@ -845,7 +845,7 @@ describe RabbitMQ::HTTP::Client do
       it "raises NotFound" do
         expect do
           subject.vhost_info(Time.now.to_i.to_s)
-        end.to raise_error(Faraday::Error::ResourceNotFound)
+        end.to raise_error(Faraday::ResourceNotFound)
       end
     end
 
@@ -1034,7 +1034,7 @@ describe RabbitMQ::HTTP::Client do
 
       expect do
         subject.list_permissions_of("/", "alt3")
-      end.to raise_error(Faraday::Error::ResourceNotFound)
+      end.to raise_error(Faraday::ResourceNotFound)
     end
   end
 


### PR DESCRIPTION
Bumping gems to the following versions:

rspec to version 3.9
bunny to version 2.15.0
hashie to version 4.1
multi_json to version 1.14.1
faraday to version 1.0.1
faraday-middleware to version 1.0