### PR TITLE
Initial API changes for 2.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,29 @@
-## Changes Between 1.15.0 and 1.16.0 (unreleased)
+## Changes Between 1.15.0 and 2.0.0 (unreleased)
 
-No changes yet.
+### Health Check Endpoint Changes
+
+`RabbitMQ::HTTP::Client#aliveness_test` has been removed. The endpoint has been deprecated
+in favor of [more focussed health check endpoints](https://www.rabbitmq.com/monitoring.html#health-checks):
+
+ * `GET  {hostname}:15672/api/health/checks/alarms`
+ * `GET  {hostname}:15672/api/health/checks/local-alarms`
+ * `GET  {hostname}:15672/api/health/checks/virtual-hosts`
+ * `GET  {hostname}:15672/api/health/checks/node-is-quorum-critical`
+ * `GET  {hostname}:15672/api/health/checks/node-is-mirror-sync-critical`
+ * `GET  {hostname}:15672/api/health/checks/port-listener/{port}`
+ * `GET  {hostname}:15672/api/health/checks/protocol-listener/{protocol}`
+ * `GET  {hostname}:15672/api/health/checks/certificate-expiration/{within}/{unit}`
+
+Support for those endpoints in `RabbitMQ::HTTP::Client` is TBD.
+### User Tags Type Change
+
+User tags returned by the `RabbitMQ::HTTP::Client#list_users` and `RabbitMQ::HTTP::Client#user_info`
+methods are now arrays of strings instead of comma-separated strings.
+
+Internally the method encodes both command-separated strings and JSON arrays in API responses
+to support response types from RabbitMQ 3.9 and earlier versions.
+
+See https://github.com/rabbitmq/rabbitmq-server/pull/2676 for details.
 
 ## Changes Between 1.14.0 and 1.15.0 (February 16th, 2021)
 ### Content Length Detection Changes

--- a/lib/rabbitmq/http/client/version.rb
+++ b/lib/rabbitmq/http/client/version.rb
@@ -1,7 +1,7 @@
 module RabbitMQ
   module HTTP
     class Client
-      VERSION = "1.16.0.pre"
+      VERSION = "2.0.0.pre"
     end
   end
 end

--- a/spec/integration/api_endpoints_spec.rb
+++ b/spec/integration/api_endpoints_spec.rb
@@ -851,80 +851,7 @@ describe RabbitMQ::HTTP::Client do
 
   end
 
-  describe "PUT /api/vhosts/:name" do
-    gen = Rantly.new
 
-    [
-      "http-created",
-      "http_created",
-      "http created",
-      "создан по хатэтэпэ",
-      "creado a través de HTTP",
-      "通过http",
-      "HTTP를 통해 생성",
-      "HTTPを介して作成",
-      "created over http?",
-      "created @ http API",
-      "erstellt über http",
-      "http पर बनाया",
-      "ถูกสร้างขึ้นผ่าน HTTP",
-      "±!@^&#*"
-    ].each do |vhost|
-      context "when vhost name is #{vhost}" do
-        it "creates a vhost" do
-          subject.create_vhost(vhost)
-          subject.create_vhost(vhost)
-
-          v = subject.vhost_info(vhost)
-          expect(v.name).to eq(vhost)
-
-          subject.delete_vhost(v.name)
-        end
-      end
-    end
-
-    200.times do
-      vhost = gen.string
-
-      context "when vhost name is #{vhost}" do
-        it "creates a vhost" do
-          subject.create_vhost(vhost)
-          subject.create_vhost(vhost)
-
-          v = subject.vhost_info(vhost)
-          expect(v.name).to eq(vhost)
-
-          subject.delete_vhost(v.name)
-        end
-      end
-    end
-  end
-
-  describe "DELETE /api/vhosts/:name" do
-    let(:vhost) { "http-created2" }
-
-    it "deletes a vhost" do
-      subject.create_vhost(vhost)
-      subject.delete_vhost(vhost)
-    end
-
-    gen = Rantly.new
-    200.times do
-      vhost = gen.string
-
-      context "when vhost #{vhost} is deleted immediately after being created" do
-        it "creates a vhost" do
-          subject.create_vhost(vhost)
-          subject.create_vhost(vhost)
-
-          v = subject.vhost_info(vhost)
-          expect(v.name).to eq(vhost)
-
-          subject.delete_vhost(v.name)
-        end
-      end
-    end
-  end
 
   describe "GET /api/vhosts/:name/permissions" do
     it "returns a list of permissions in a vhost" do
@@ -950,7 +877,8 @@ describe RabbitMQ::HTTP::Client do
     it "returns information about a user" do
       u = subject.user_info("guest")
       expect(u.name).to eq("guest")
-      expect(u.tags).to eq("administrator")
+
+      expect(u.tags).to include("administrator")
     end
   end
 
@@ -960,7 +888,7 @@ describe RabbitMQ::HTTP::Client do
         subject.update_user("alt-user", tags: "http, policymaker, management", password: "alt-user")
 
         u = subject.user_info("alt-user")
-        expect(u.tags).to eq("http,policymaker,management")
+        expect(u.tags.sort).to eq(["http", "policymaker", "management"].sort)
       end
     end
 
@@ -969,7 +897,7 @@ describe RabbitMQ::HTTP::Client do
         subject.update_user("alt-user", password: "alt-user")
 
         u = subject.user_info("alt-user")
-        expect(u.tags).to eq("")
+        expect(u.tags).to eq([])
       end
     end
   end
@@ -1068,18 +996,6 @@ describe RabbitMQ::HTTP::Client do
     end
   end
 
-
-  #
-  # Aliveness Test
-  #
-
-  describe "GET /api/aliveness-test/:vhost" do
-    it "performs aliveness check" do
-      r = subject.aliveness_test("/")
-
-      expect(r).to eq(true)
-    end
-  end
 
   #
   # Accept Faraday adapter options

--- a/spec/integration/generative_spec.rb
+++ b/spec/integration/generative_spec.rb
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+require "spec_helper"
+
+describe RabbitMQ::HTTP::Client do
+  let(:endpoint) { "http://127.0.0.1:15672" }
+
+  subject do
+    described_class.connect(endpoint, :username => "guest", :password => "guest")
+  end
+
+  before :each do
+    @conn = Bunny.new
+    @conn.start
+  end
+
+  after :each do
+    @conn.close
+  end
+
+  #
+  # Helpers
+  #
+
+  # Statistics tables in the server are updated asynchronously,
+  # in particular starting with rabbitmq/rabbitmq-management#236,
+  # so in some cases we need to wait before GET'ing e.g. a newly opened connection.
+  def await_event_propagation
+    # same number as used in rabbit-hole test suite. Works OK.
+    sleep 1
+  end
+
+
+  describe "PUT /api/vhosts/:name" do
+    gen = Rantly.new
+
+    [
+      "http-created",
+      "http_created",
+      "http created",
+      "создан по хатэтэпэ",
+      "creado a través de HTTP",
+      "通过http",
+      "HTTP를 통해 생성",
+      "HTTPを介して作成",
+      "created over http?",
+      "created @ http API",
+      "erstellt über http",
+      "http पर बनाया",
+      "ถูกสร้างขึ้นผ่าน HTTP",
+      "±!@^&#*"
+    ].each do |vhost|
+      context "when vhost name is #{vhost}" do
+        it "creates a vhost" do
+          subject.create_vhost(vhost)
+          subject.create_vhost(vhost)
+
+          v = subject.vhost_info(vhost)
+          expect(v.name).to eq(vhost)
+
+          subject.delete_vhost(v.name)
+        end
+      end
+    end
+
+    200.times do
+      vhost = gen.string
+
+      context "when vhost name is #{vhost}" do
+        it "creates a vhost" do
+          subject.create_vhost(vhost)
+          subject.create_vhost(vhost)
+
+          v = subject.vhost_info(vhost)
+          expect(v.name).to eq(vhost)
+
+          subject.delete_vhost(v.name)
+        end
+      end
+    end
+  end
+
+
+
+  describe "DELETE /api/vhosts/:name" do
+    let(:vhost) { "http-created2" }
+
+    it "deletes a vhost" do
+      subject.create_vhost(vhost)
+      subject.delete_vhost(vhost)
+    end
+
+    gen = Rantly.new
+    200.times do
+      vhost = gen.string
+
+      context "when vhost #{vhost} is deleted immediately after being created" do
+        it "creates a vhost" do
+          subject.create_vhost(vhost)
+          subject.create_vhost(vhost)
+
+          v = subject.vhost_info(vhost)
+          expect(v.name).to eq(vhost)
+
+          subject.delete_vhost(v.name)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
 * User tags are now formatted as arrays (both pre-3.9 and 3.9+ API response formats are supported)
 * `#aliveness_test` is removed because it's deprecated
 * Integration tests are split into two: a "fast" one and a generative one