### PR TITLE
Support publishing to an exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ This gem is a [RabbitMQ HTTP API](http://hg.rabbitmq.com/rabbitmq-management/raw
  * Getting information about vhosts, users, permissions
  * Getting information about enabled plugins, protocols, their ports, etc
  * Managing vhosts, users, permissions
+ * Publishing messages via HTTP
 
 and will support more HTTP API features in the future
 
- * Publishing messages via HTTP
  * Operations on components/extensions
  * Operations on federation policies
 
@@ -203,6 +203,9 @@ client.list_bindings_by_source("/", "log.events")
 
 # List all exchanges in a vhost for which an exchange is the destination
 client.list_bindings_by_destination("/", "command.handlers.email")
+
+# publish to an exchange
+client.exchange_publish("/", "log.events", routing_key: "routing-key-here", payload: "body here")
 ```
 
 ### Operations on Queues

--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -147,6 +147,19 @@ module RabbitMQ
         decode_resource(@connection.get("exchanges/#{encode_uri_path_segment(vhost)}/#{encode_uri_path_segment(name)}"))
       end
 
+      def exchange_publish(vhost, name, attributes)
+        opts = {
+          properties: {},
+          payload_encoding: "string",
+        }.merge(attributes)
+        path = "exchanges/#{encode_uri_path_segment(vhost)}/#{encode_uri_path_segment(name)}/publish"
+        response = @connection.post(path) do |req|
+          req.headers['Content-Type'] = 'application/json'
+          req.body = MultiJson.dump(opts)
+        end
+        decode_resource(response)
+      end
+
       def list_bindings_by_source(vhost, exchange, query = {})
         decode_resource_collection(@connection.get("exchanges/#{encode_uri_path_segment(vhost)}/#{encode_uri_path_segment(exchange)}/bindings/source", query))
       end

--- a/spec/integration/api_endpoints_spec.rb
+++ b/spec/integration/api_endpoints_spec.rb
@@ -385,23 +385,25 @@ describe RabbitMQ::HTTP::Client do
     let(:queue_name) { "my_queue" }
     let(:vhost) { "/" }
     let(:exchange) { "" }
+    let(:payload) { "payload" }
 
     before :each do
       @channel    = @conn.create_channel
-      @channel.queue(queue_name, durable: false, auto_delete: true)
     end
     after :each do
-      @channel.queue_delete queue_name
       @channel.close
     end
 
     it "publishes a messages to the exchange" do
+      queue = Bunny::Queue.new(@channel, queue_name, auto_delete: true)
       opts = {
         routing_key: queue_name,
-        payload: "message body",
+        payload: payload,
       }
       response = subject.exchange_publish(vhost, exchange, opts)
-      expect(response.routed).to eq true
+      delivery_info, properties, received_payload = queue.pop
+      expect(received_payload).to eq payload
+      queue.delete
     end
   end
 

--- a/spec/integration/api_endpoints_spec.rb
+++ b/spec/integration/api_endpoints_spec.rb
@@ -381,9 +381,28 @@ describe RabbitMQ::HTTP::Client do
   end
 
 
-
   describe "POST /api/exchanges/:vhost/:name/publish" do
-    it "publishes a messages to the exchange"
+    let(:queue_name) { "my_queue" }
+    let(:vhost) { "/" }
+    let(:exchange) { "" }
+
+    before :each do
+      @channel    = @conn.create_channel
+      @channel.queue(queue_name, durable: false, auto_delete: true)
+    end
+    after :each do
+      @channel.queue_delete queue_name
+      @channel.close
+    end
+
+    it "publishes a messages to the exchange" do
+      opts = {
+        routing_key: queue_name,
+        payload: "message body",
+      }
+      response = subject.exchange_publish(vhost, exchange, opts)
+      expect(response.routed).to eq true
+    end
   end
 
 


### PR DESCRIPTION
Adds support for the exchange/publish endpoint to allow publishing messages via the API.

I wasn't sure what to call the new `Client` method, so I went with the very simple `exchange_publish( ... )` which seems to match the API endpoint. Some alternatives might be `publish_to_exchange( ... )` or `publish_message( ... )`, etc. Let me know if a different name is preferred.