### PR TITLE
Add safe guard to undefined body

### DIFF
--- a/lib/rabbitmq/http/client/response_helper.rb
+++ b/lib/rabbitmq/http/client/response_helper.rb
@@ -13,7 +13,7 @@ module RabbitMQ
       end
 
       def decode_resource(response)
-        if response.body.empty?
+        if !defined?(response.body) || response.body.empty?
           Hashie::Mash.new
         else
           decode_response_body(response.body)
@@ -21,7 +21,7 @@ module RabbitMQ
       end
 
       def decode_response_body(body)
-        if body.empty?
+        if !defined?(body) || body.empty?
           Hashie::Mash.new
         else
           Hashie::Mash.new(body)


### PR DESCRIPTION
When response doesn't contain a body, it was failing due to

```
undefined method `empty?' for nil:NilClass
```

This fixes the issue https://github.com/ruby-amqp/rabbitmq_http_api_client/issues/52