### PR TITLE
Add support for topic-permissions

### DIFF
--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -299,7 +299,29 @@ module RabbitMQ
         decode_resource(@connection.delete("permissions/#{encode_uri_path_segment(vhost)}/#{encode_uri_path_segment(user)}"))
       end
 
+      def list_topic_permissions(vhost = nil, query = {})
+        path = if vhost
+                 "vhosts/#{encode_uri_path_segment(vhost)}/topic-permissions"
+                else
+                  "topic-permissions"
+                end
 
+        decode_resource_collection(@connection.get(path, query))
+      end
+
+      def list_topic_permissions_of(vhost, user)
+        path = "topic-permissions/#{encode_uri_path_segment(vhost)}/#{encode_uri_path_segment(user)}"
+        decode_resource_collection(@connection.get(path))
+      end
+
+      def update_topic_permissions_of(vhost, user, attributes)
+        response = @connection.put("topic-permissions/#{encode_uri_path_segment(vhost)}/#{encode_uri_path_segment(user)}") do |req|
+          req.headers['Content-Type'] = "application/json"
+          req.body = MultiJson.dump(attributes)
+        end
+
+        nil
+      end
 
       def list_users(query = {})
         results = decode_resource_collection(@connection.get("users", query))

--- a/spec/integration/api_endpoints_spec.rb
+++ b/spec/integration/api_endpoints_spec.rb
@@ -967,6 +967,44 @@ describe RabbitMQ::HTTP::Client do
   end
 
   #
+  # Topic permissions 
+  #
+
+  describe "GET /api/topic-permissions" do
+    it "returns a list of topic permissions" do
+      xs = subject.list_topic_permissions
+      expect(xs.first.read).to_not be_nil
+    end
+
+  end
+
+  describe "GET /api/topic-permissions/:vhost/:user" do
+    it "returns a list of topic permissions of a user in a vhost" do
+      p = subject.list_topic_permissions_of("/", "guest").first
+
+      expect(p.exchange).to eq("amq.topic")
+      expect(p.read).to eq(".*")
+      expect(p.write).to eq(".*")
+    end
+  end
+
+  describe "PUT /api/topic-permissions/:vhost/:user" do
+    it "updates the topic permissions of a user in a vhost" do
+      subject.update_topic_permissions_of(
+        "/",
+        "guest",
+        { exchange: "amq.topic", read: ".*", write: ".*" }
+      )
+
+      p = subject.list_topic_permissions_of("/", "guest").first
+
+      expect(p.exchange).to eq("amq.topic")
+      expect(p.read).to eq(".*")
+      expect(p.write).to eq(".*")
+    end
+  end
+
+  #
   # Parameters
   #
 


### PR DESCRIPTION
Adds support for the /api/topic-permissions endpoints

As far as I can tell, the PUT /api/topic-permissions/:vhost/:user doesn't return anything, I always got `""` in my testing.