### PR TITLE
Handle 204 responses with HTTP keepalive

### DIFF
--- a/lib/rabbitmq/http/client/response_helper.rb
+++ b/lib/rabbitmq/http/client/response_helper.rb
@@ -13,7 +13,7 @@ module RabbitMQ
       end
 
       def decode_resource(response)
-        if response.nil? || response.body.empty?
+        if response.nil? || response.body.nil? || response.body.empty?
           Hashie::Mash.new
         else
           decode_response_body(response.body)


### PR DESCRIPTION
If the HTTP API is behind a proxy which has HTTP keepalive enabled, Faraday will assign a nil body on 204 responses.