### PR TITLE
Add support for if-unused and if-empty for delete_queue

### DIFF
--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -177,8 +177,12 @@ module RabbitMQ
         decode_resource(response)
       end
 
-      def delete_queue(vhost, name)
-        decode_resource(@connection.delete("queues/#{encode_uri_path_segment(vhost)}/#{encode_uri_path_segment(name)}"))
+      def delete_queue(vhost, name, if_unused = false, if_empty = false)
+        response = @connection.delete("queues/#{encode_uri_path_segment(vhost)}/#{encode_uri_path_segment(name)}") do |req|
+          req.params["if-unused"] = true if if_unused
+          req.params["if-empty"] = true if if_empty
+        end
+        decode_resource(response)
       end
 
       def list_queue_bindings(vhost, queue, query = {})

--- a/spec/integration/api_endpoints_spec.rb
+++ b/spec/integration/api_endpoints_spec.rb
@@ -506,6 +506,32 @@ describe RabbitMQ::HTTP::Client do
       q = @channel.queue(queue_name, durable: false)
       subject.delete_queue("/", queue_name)
     end
+
+    it "doesn't delete non-empty queue if if-empty is set" do
+      q = @channel.queue(queue_name, durable: false)
+      q.publish("hello")
+      expect do
+        subject.delete_queue("/", queue_name, false, true)
+      end.to raise_error(Faraday::ClientError)
+
+      subject.purge_queue("/", q.name)
+      subject.delete_queue("/", queue_name, false, true)
+    end
+
+    it "doesn't delete used queue if if-unused is set" do
+      q = @channel.queue(queue_name, durable: false)
+      # Simulate the queue being used by creating a consumer
+      consumer = q.subscribe do |_delivery_info, _properties, _body|
+        # consumer block
+      end
+
+      expect do
+        subject.delete_queue("/", queue_name, true, false)
+      end.to raise_error(Faraday::ClientError)
+
+      consumer.cancel
+      subject.delete_queue("/", queue_name, false, true)
+    end
   end
 
   describe "GET /api/queues/:vhost/:name/bindings" do

--- a/spec/integration/api_endpoints_spec.rb
+++ b/spec/integration/api_endpoints_spec.rb
@@ -522,7 +522,10 @@ describe RabbitMQ::HTTP::Client do
 
     it "doesn't delete used queue if if-unused is set" do
       q = @channel.queue(queue_name, durable: false)
-      consumer = q.subscribe
+      # Simulate the queue being used by creating a consumer
+      consumer = q.subscribe do |_delivery_info, _properties, _body|
+        # consumer block
+      end
 
       expect do
         subject.delete_queue("/", queue_name, true, false)

--- a/spec/integration/api_endpoints_spec.rb
+++ b/spec/integration/api_endpoints_spec.rb
@@ -505,6 +505,7 @@ describe RabbitMQ::HTTP::Client do
     it "deletes a queue" do
       q = @channel.queue(queue_name, durable: false)
       subject.delete_queue("/", queue_name)
+      expect { subject.queue_info("/", queue_name) }.to raise_error(Faraday::ResourceNotFound)
     end
 
     it "doesn't delete non-empty queue if if-empty is set" do
@@ -516,21 +517,20 @@ describe RabbitMQ::HTTP::Client do
 
       subject.purge_queue("/", q.name)
       subject.delete_queue("/", queue_name, false, true)
+      expect { subject.queue_info("/", queue_name) }.to raise_error(Faraday::ResourceNotFound)
     end
 
     it "doesn't delete used queue if if-unused is set" do
       q = @channel.queue(queue_name, durable: false)
-      # Simulate the queue being used by creating a consumer
-      consumer = q.subscribe do |_delivery_info, _properties, _body|
-        # consumer block
-      end
+      consumer = q.subscribe
 
       expect do
         subject.delete_queue("/", queue_name, true, false)
       end.to raise_error(Faraday::ClientError)
 
       consumer.cancel
-      subject.delete_queue("/", queue_name, false, true)
+      subject.delete_queue("/", queue_name, true, false)
+      expect { subject.queue_info("/", queue_name) }.to raise_error(Faraday::ResourceNotFound)
     end
   end
 


### PR DESCRIPTION
From [HTTP API docs](https://rawcdn.githack.com/rabbitmq/rabbitmq-server/v3.12.12/deps/rabbitmq_management/priv/www/api/index.html)

> When DELETEing a queue you can add the query string parameters if-empty=true and / or if-unused=true. These prevent the delete from succeeding if the queue contains messages, or has consumers, respectively.

This PR adds supports for providing these query parameters and the tests to confirm the behaviour.