### PR TITLE
Support Faraday version 2.x

### DIFF
--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -450,11 +450,7 @@ module RabbitMQ
         adapter = options.delete(:adapter) || Faraday.default_adapter
 
         @connection = Faraday.new(options) do |conn|
-          if Gem::Version.new(Faraday::VERSION) < Gem::Version.new("2.0")
-            conn.request :basic_auth, user, password
-          else
-            conn.request :authorization, :basic, user, password
-          end
+          conn.request :authorization, :basic, user, password
 
           conn.use        Faraday::FollowRedirects::Middleware, :limit => 3
           conn.use        Faraday::Response::RaiseError

--- a/lib/rabbitmq/http/client.rb
+++ b/lib/rabbitmq/http/client.rb
@@ -450,7 +450,7 @@ module RabbitMQ
         adapter = options.delete(:adapter) || Faraday.default_adapter
 
         @connection = Faraday.new(options) do |conn|
-          conn.request :authorization, :basic, user, password
+          conn.request    :authorization, :basic, user, password
 
           conn.use        Faraday::FollowRedirects::Middleware, :limit => 3
           conn.use        Faraday::Response::RaiseError

--- a/lib/rabbitmq/http/client/health_checks.rb
+++ b/lib/rabbitmq/http/client/health_checks.rb
@@ -1,6 +1,6 @@
 require "hashie"
 require "faraday"
-require "faraday_middleware"
+require "faraday/follow_redirects"
 require "multi_json"
 require "uri"
 

--- a/lib/rabbitmq/http/client/request_helper.rb
+++ b/lib/rabbitmq/http/client/request_helper.rb
@@ -1,6 +1,6 @@
 require "hashie"
 require "faraday"
-require "faraday_middleware"
+require "faraday/follow_redirects"
 require "multi_json"
 require "uri"
 

--- a/lib/rabbitmq/http/client/response_helper.rb
+++ b/lib/rabbitmq/http/client/response_helper.rb
@@ -1,6 +1,6 @@
 require "hashie"
 require "faraday"
-require "faraday_middleware"
+require "faraday/follow_redirects"
 require "multi_json"
 require "uri"
 

--- a/rabbitmq_http_api_client.gemspec
+++ b/rabbitmq_http_api_client.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency    'addressable', '~> 2.7'
   gem.add_dependency    'hashie', '~> 4.1'
   gem.add_dependency    'multi_json', '~> 1.15'
-  gem.add_dependency    'faraday', '>= 1.3', '< 3'
+  gem.add_dependency    'faraday', '~> 2.0'
   gem.add_dependency    'faraday-follow_redirects', '~> 0.3'
 end

--- a/rabbitmq_http_api_client.gemspec
+++ b/rabbitmq_http_api_client.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency    'addressable', '~> 2.7'
   gem.add_dependency    'hashie', '~> 4.1'
   gem.add_dependency    'multi_json', '~> 1.15'
-  gem.add_dependency    'faraday', '~> 1.3'
-  gem.add_dependency    'faraday_middleware', '~> 1.2'
+  gem.add_dependency    'faraday', '>= 1.3', '< 3'
+  gem.add_dependency    'faraday-follow_redirects', '~> 0.3'
 end


### PR DESCRIPTION
Adds support for Faraday 2.x. For this upgrade the [Faraday Upgrading guide](https://github.com/lostisland/faraday/blob/main/UPGRADING.md) was used.

Unfortunately basic authentication implementations for Faraday 1.x and 2.x are completely different and therefore I had to add a version check to support both versions.