### PR TITLE
Feature/dependency constraints

### DIFF
--- a/rabbitmq_http_api_client.gemspec
+++ b/rabbitmq_http_api_client.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency    'addressable', '~> 2.8'
-  gem.add_dependency    'hashie', '~> 5.0'
-  gem.add_dependency    'multi_json', '~> 1.17'
-  gem.add_dependency    'faraday', '~> 2.14'
+  gem.add_dependency    'addressable', '~> 2.7'
+  gem.add_dependency    'hashie', '>= 4.1'
+  gem.add_dependency    'multi_json', '~> 1.15'
+  gem.add_dependency    'faraday', '~> 2.9'
   gem.add_dependency    'faraday-follow_redirects', '~> 0.4'
 end


### PR DESCRIPTION
#### fix: partially revert dependency constraint changes from #67
In #67, I proposed to update the dependency constraints to allow the gem
to be compatible with newer gem versions.

I now see that what I did was wrong, while no code changes were done
(meaning that the dependency constraints as they were would still work),
I made the gem conflict with working gem versions.

I updated the constraints to reflect what I was actually trying to do:
  Make it compatible with newer gem versions, not break compatibility
  with older working ones.

Signed-off-by: Frederik Thuysbaert <frederik.thuysbaert@combell.group>

---------